### PR TITLE
Fix code scanning alert no. 108: Information exposure through a stack trace

### DIFF
--- a/api/src/api/AttributeController.ts
+++ b/api/src/api/AttributeController.ts
@@ -112,7 +112,7 @@ export default class AttributeController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -126,7 +126,7 @@ export default class AttributeController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -140,7 +140,7 @@ export default class AttributeController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -150,7 +150,7 @@ export default class AttributeController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -160,7 +160,7 @@ export default class AttributeController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/CategoryController.ts
+++ b/api/src/api/CategoryController.ts
@@ -30,7 +30,7 @@ export default class CategoryController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -40,7 +40,7 @@ export default class CategoryController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -50,7 +50,7 @@ export default class CategoryController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -64,7 +64,7 @@ export default class CategoryController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -74,7 +74,7 @@ export default class CategoryController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/CategoryController.ts
+++ b/api/src/api/CategoryController.ts
@@ -30,7 +30,7 @@ export default class CategoryController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -40,7 +40,7 @@ export default class CategoryController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -50,7 +50,7 @@ export default class CategoryController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -64,7 +64,7 @@ export default class CategoryController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -74,7 +74,7 @@ export default class CategoryController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 }

--- a/api/src/api/ItemController.ts
+++ b/api/src/api/ItemController.ts
@@ -31,7 +31,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.getAll()
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }
@@ -41,7 +41,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.getAllByCategory(req.params.category)
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }
@@ -55,7 +55,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
         res.status(404).send('Data not found')
       }
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }
@@ -65,7 +65,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.create(req.body)
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }
@@ -79,7 +79,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
         res.status(404).send('Data not found')
       }
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }
@@ -89,7 +89,7 @@ export default class ItemController { // Changed from RatedItemController to Ite
       await this.itemService.delete(parseInt(req.params.id, 10))
       res.status(204).send()
     } catch (error) {
-      console.error(error.stack || error)
+      console.error((error as Error).stack || error)
       res.status(500).send('An internal server error occurred')
     }
   }

--- a/api/src/api/ItemController.ts
+++ b/api/src/api/ItemController.ts
@@ -31,8 +31,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.getAll()
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -41,8 +41,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.getAllByCategory(req.params.category)
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -55,8 +55,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
         res.status(404).send('Data not found')
       }
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -65,8 +65,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
       const data = await this.itemService.create(req.body)
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -79,8 +79,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
         res.status(404).send('Data not found')
       }
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -89,8 +89,8 @@ export default class ItemController { // Changed from RatedItemController to Ite
       await this.itemService.delete(parseInt(req.params.id, 10))
       res.status(204).send()
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error(error.stack || error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/LoginController.ts
+++ b/api/src/api/LoginController.ts
@@ -26,8 +26,8 @@ export default class LoginController {
         res.status(401).send('Invalid username or password')
       }
     } catch (error) {
-      console.error(error)
-      res.status(500).send(error)
+      console.error('Exception occurred:', error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/RatedItemController.ts
+++ b/api/src/api/RatedItemController.ts
@@ -32,7 +32,7 @@ export default class RatedItemController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -42,7 +42,7 @@ export default class RatedItemController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -56,7 +56,7 @@ export default class RatedItemController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -66,7 +66,7 @@ export default class RatedItemController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -80,7 +80,7 @@ export default class RatedItemController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -90,7 +90,7 @@ export default class RatedItemController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/UserController.ts
+++ b/api/src/api/UserController.ts
@@ -33,7 +33,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -43,7 +43,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -53,7 +53,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -63,7 +63,7 @@ export default class UserController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -77,7 +77,7 @@ export default class UserController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -87,7 +87,7 @@ export default class UserController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send("An internal server error occurred")
+      res.status(500).send('An internal server error occurred')
     }
   }
 }

--- a/api/src/api/UserController.ts
+++ b/api/src/api/UserController.ts
@@ -33,7 +33,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -43,7 +43,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -53,7 +53,7 @@ export default class UserController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -63,7 +63,7 @@ export default class UserController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -77,7 +77,7 @@ export default class UserController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 
@@ -87,7 +87,7 @@ export default class UserController {
       res.status(204).send()
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send("An internal server error occurred")
     }
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/rate-my-everything/security/code-scanning/108](https://github.com/cristiadu/rate-my-everything/security/code-scanning/108)

To fix the problem, we need to ensure that detailed error information is not sent back to the client. Instead, we should log the error details on the server and send a generic error message to the client. This can be achieved by modifying the catch block to log the error and send a generic message.

- Modify the catch block in the `login` method to log the error details on the server.
- Send a generic error message to the client instead of the error object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
