### PR TITLE
Fix code scanning alert no. 98: Information exposure through a stack trace

### DIFF
--- a/api/src/api/AttributeController.ts
+++ b/api/src/api/AttributeController.ts
@@ -44,7 +44,7 @@ export default class AttributeController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -54,7 +54,7 @@ export default class AttributeController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -64,7 +64,7 @@ export default class AttributeController {
       res.status(200).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -78,7 +78,7 @@ export default class AttributeController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -92,7 +92,7 @@ export default class AttributeController {
       }
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 
@@ -102,7 +102,7 @@ export default class AttributeController {
       res.status(201).send(JSON.stringify(data))
     } catch (error) {
       console.error(error)
-      res.status(500).send(error)
+      res.status(500).send('An internal server error occurred')
     }
   }
 


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/rate-my-everything/security/code-scanning/98](https://github.com/cristiadu/rate-my-everything/security/code-scanning/98)

To fix the problem, we need to ensure that the stack trace or any sensitive information contained in the error object is not sent to the end user. Instead, we should log the error on the server and send a generic error message to the user. This can be achieved by modifying the catch blocks to log the error and send a generic message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
