### PR TITLE
Fix code scanning alert no. 105: Missing rate limiting

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,8 @@
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.2.2",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.7",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 
 import { DataSource } from 'typeorm'
 import express from 'express'
+import rateLimit from 'express-rate-limit'
 import cors from 'cors'
 import bodyParser from 'body-parser'
 
@@ -14,6 +15,16 @@ import Category from './models/Category'
 import { routes, authenticationFilter } from './routes/RouterAuthConfig'
 
 const app = express()
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+})
+
+// apply rate limiter to all requests
+app.use(limiter)
+
 app.use(cors())
 app.use(bodyParser.json())
 


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/rate-my-everything/security/code-scanning/105](https://github.com/cristiadu/rate-my-everything/security/code-scanning/105)

To fix the problem, we need to introduce rate limiting middleware to the Express application. The `express-rate-limit` package is a well-known solution for this purpose. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all incoming requests before any other middleware or routes are processed.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `api/src/index.ts` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the Express application using `app.use`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
