### PR TITLE
Fix code scanning alert no. 105: Missing rate limiting

### DIFF
--- a/api/src/api/LoginController.ts
+++ b/api/src/api/LoginController.ts
@@ -1,5 +1,6 @@
 import { Request, Response, Router } from 'express'
 import UserService from '../services/UserService'
+import rateLimit from 'express-rate-limit'
 
 export default class LoginController {
   public router = Router()
@@ -12,7 +13,11 @@ export default class LoginController {
   }
 
   public initializeRoutes() {
-    this.router.post('/', this.login)
+    const limiter = rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 100, // limit each IP to 100 requests per windowMs
+    })
+    this.router.post('/', limiter, this.login)
     // Add more routes as needed
   }
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -23,8 +23,6 @@ const limiter = rateLimit({
 })
 
 // apply rate limiter to all requests
-app.use(limiter)
-
 app.use(cors())
 app.use(bodyParser.json())
 
@@ -44,6 +42,7 @@ DBConnection.initialize()
   .then(() => {
     console.log('Data Source has been initialized!')
 
+    app.use(limiter)
     app.use(authenticationFilter)
 
     // Use the routes


### PR DESCRIPTION
Fixes [https://github.com/cristiadu/rate-my-everything/security/code-scanning/105](https://github.com/cristiadu/rate-my-everything/security/code-scanning/105)

To fix the problem, we need to ensure that the `authenticationFilter` is protected by the rate limiter. This can be achieved by applying the rate limiter before the `authenticationFilter` in the middleware chain. This way, the rate limiter will limit the number of requests that reach the `authenticationFilter`, preventing potential denial-of-service attacks.

We will move the rate limiter setup to be applied before the `authenticationFilter` in the middleware chain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
